### PR TITLE
Add JStachio to HtmlFlow benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 *.ear
 .project
 /.idea/*
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
 		<pebble.version>3.0.6</pebble.version>
 		<mustache.version>0.9.5</mustache.version>
+		<jstachio.version>1.3.4</jstachio.version>
 		<freemarker.version>2.3.28</freemarker.version>
 		<velocity.version>1.7</velocity.version>
 		<thymeleaf.version>3.0.11.RELEASE</thymeleaf.version>
@@ -110,8 +111,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
 			<plugin>
@@ -165,6 +166,18 @@
 			<groupId>com.github.spullara.mustache.java</groupId>
 			<artifactId>compiler</artifactId>
 			<version>${mustache.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jstach</groupId>
+			<artifactId>jstachio</artifactId>
+			<version>${jstachio.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jstach</groupId>
+			<artifactId>jstachio-apt</artifactId>
+			<version>${jstachio.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.freemarker</groupId>

--- a/src/main/java/com/mitchellbosecke/benchmark/JStachio.java
+++ b/src/main/java/com/mitchellbosecke/benchmark/JStachio.java
@@ -1,0 +1,91 @@
+package com.mitchellbosecke.benchmark;
+
+import java.util.List;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+
+import com.mitchellbosecke.benchmark.model.Presentation;
+import com.mitchellbosecke.benchmark.model.Stock;
+
+import io.jstach.jstache.JStache;
+import io.jstach.jstache.JStacheConfig;
+import io.jstach.jstache.JStacheFlags;
+import io.jstach.jstache.JStacheFlags.Flag;
+import io.jstach.jstache.JStacheLambda;
+import io.jstach.jstachio.escapers.PlainText;
+
+public class JStachio extends BaseBenchmark {
+
+    // Let us cheat like rocker and jte
+    private static final ThreadLocal<StringBuilder> buffer = ThreadLocal.withInitial(() -> new StringBuilder(1024 * 8));
+    
+    private List<Stock> items;
+    private Iterable<Presentation> presentations;
+    private StocksModel stocksModel;
+    private PresentationsModel presentationsModel;
+    private JStachioStocksTemplate stocksTemplate;
+    private JStachioPresentationsTemplate presentationsTemplate;
+    
+    @Setup
+    public void setup() {
+        items = Stock.dummyItems();
+        stocksModel = new StocksModel(items);
+        stocksTemplate = JStachioStocksTemplate.of();
+        presentations = Presentation.dummyItems();
+        presentationsModel = new PresentationsModel(presentations);
+        presentationsTemplate = JStachioPresentationsTemplate.of();
+    }
+
+    @Benchmark
+    public String stocks() {
+        StringBuilder sb = buffer.get();
+        sb.setLength(0);
+        return stocksTemplate.execute(stocksModel, sb).toString();
+    }
+    
+    @Benchmark
+    public String presentations() {
+        StringBuilder sb = buffer.get();
+        sb.setLength(0);
+        return presentationsTemplate.execute(presentationsModel, sb).toString();
+    }
+
+    @JStache(path = "templates/stocks.jstachio.html", 
+            name="JStachioStocksTemplate")
+    @JStacheConfig(contentType=PlainText.class)
+    @JStacheFlags(flags = {Flag.NO_NULL_CHECKING})
+    public static class StocksModel {
+
+        public final List<Stock> items;
+
+        public StocksModel(List<Stock> items) {
+            this.items = items;
+        }
+        
+        @JStacheLambda
+        public boolean isPositive(Stock stock) {
+            return stock.getChange() > 0;
+        }
+        
+        @JStacheLambda
+        public boolean isEven(int index) {
+            return index % 2 == 0;
+        }
+
+    }
+
+    @JStache(path = "templates/presentations.jstachio.html", 
+            name="JStachioPresentationsTemplate")
+    @JStacheConfig(contentType=PlainText.class)
+    @JStacheFlags(flags = {Flag.NO_NULL_CHECKING})
+    public static class PresentationsModel{
+
+        public final Iterable<Presentation> presentationItems;
+
+        public PresentationsModel(Iterable<Presentation> presentationItems) {
+            this.presentationItems = presentationItems;
+        }
+
+    }
+}

--- a/src/main/resources/templates/presentations.jstachio.html
+++ b/src/main/resources/templates/presentations.jstachio.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="content-language" content="IE=Edge">
+	<title>
+		JFall 2013 Presentations - htmlApi
+	</title>
+	<link rel="Stylesheet" href="/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" media="screen">
+</head>
+<body>
+<div class="container">
+	<div class="page-header">
+		<h1>
+			JFall 2013 Presentations - htmlApi
+		</h1>
+	</div>
+	{{#presentationItems}}
+	<div class="panel panel-default">
+		<div class="panel-heading">
+			<h3 class="panel-title">
+				{{title}} - {{speakerName}}
+			</h3>
+		</div>
+		<div class="panel-body">
+			{{summary}}
+		</div>
+	</div>
+	{{/presentationItems}}
+</div>
+<script src="/webjars/jquery/3.1.1/jquery.min.js">
+</script>
+<script src="/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js">
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/stocks.jstachio.html
+++ b/src/main/resources/templates/stocks.jstachio.html
@@ -1,0 +1,85 @@
+{{! vim: set ts=4 sw=4 noexpandtab: }}
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Stock Prices</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta http-equiv="Content-Style-Type" content="text/css">
+	<meta http-equiv="Content-Script-Type" content="text/javascript">
+	<link rel="shortcut icon" href="/images/favicon.ico">
+	<link rel="stylesheet" type="text/css" href="/css/style.css" media="all">
+	<script type="text/javascript" src="/js/util.js"></script>
+	<style type="text/css">
+		/*<![CDATA[*/
+		body {
+			color: #333333;
+			line-height: 150%;
+		}
+
+		thead {
+			font-weight: bold;
+			background-color: #CCCCCC;
+		}
+
+		.odd {
+			background-color: #FFCCCC;
+		}
+
+		.even {
+			background-color: #CCCCFF;
+		}
+
+		.minus {
+			color: #FF0000;
+		}
+
+		/*]]>*/
+	</style>
+
+</head>
+
+<body>
+
+	<h1>Stock Prices</h1>
+
+	<table>
+		<thead>
+			<tr>
+				<th>#</th>
+				<th>symbol</th>
+				<th>name</th>
+				<th>price</th>
+				<th>change</th>
+				<th>ratio</th>
+			</tr>
+		</thead>
+		<tbody>
+			{{#items}}
+			<tr class="{{#-index.isEven}}{{#.}}even{{/.}}{{^.}}odd{{/.}}{{/-index.isEven}}">
+				<td>{{-index}}</td>
+				<td>
+					<a href="/stocks/{{symbol}}">{{symbol}}</a>
+				</td>
+				<td>
+					<a href="{{url}}">{{name}}</a>
+				</td>
+				<td>
+					<strong>{{price}}</strong>
+				</td>
+				{{#isPositive}}
+				{{#.}}
+				<td>{{change}}</td>
+				<td>{{ratio}}</td>
+				{{/.}}
+				{{^.}}
+				<td class="minus">{{change}}</td>
+				<td class="minus">{{ratio}}</td>
+				{{/.}}
+				{{/isPositive}}
+			</tr>
+			{{/items}}
+		</tbody>
+	</table>
+
+</body>
+</html>

--- a/src/test/java/com/mitchellbosecke/benchmark/ExpectedOutputTest.java
+++ b/src/test/java/com/mitchellbosecke/benchmark/ExpectedOutputTest.java
@@ -61,6 +61,13 @@ public class ExpectedOutputTest {
     }
 
     @Test
+    public void testJStachioOutput() throws IOException {
+        JStachio jstachio = new JStachio();
+        jstachio.setup();
+        assertOutput(jstachio.stocks());
+    }
+
+    @Test
     public void testThymeleafOutput() throws IOException, TemplateException {
         Thymeleaf thymeleaf = new Thymeleaf();
         thymeleaf.setup();

--- a/src/test/java/com/mitchellbosecke/benchmark/ExpectedPresentationsTest.java
+++ b/src/test/java/com/mitchellbosecke/benchmark/ExpectedPresentationsTest.java
@@ -44,6 +44,13 @@ public class ExpectedPresentationsTest {
         mustache.setup();
         assertOutput(mustache.presentations());
     }
+    
+    @Test
+    public void testJStachioOutput() throws IOException {
+        JStachio jstachio = new JStachio();
+        jstachio.setup();
+        assertOutput(jstachio.presentations());
+    }
 
     @Test
     public void testThymeleafOutput() throws IOException, TemplateException {


### PR DESCRIPTION
```
Benchmark                Mode  Cnt        Score       Error  Units
HtmlFlow.presentations  thrpt    6   445525.472 ±  2674.491  ops/s
HtmlFlow.stocks         thrpt    6   108397.828 ±  1109.594  ops/s
JStachio.presentations  thrpt    6  1260078.083 ± 18070.685  ops/s
JStachio.stocks         thrpt    6   235090.054 ±  6368.848  ops/s
```

Benchmarks are lies but I have a hard time believing the readme that HtmlFlow is the fastest. I also think Rocker is probably not setup correctly.

The default branch on my repo also does UTF-8 output which IMO is more important especially if we are talking about HTML output: https://github.com/agentgt/template-benchmark

Does HtmlFlow do pre-encoding.